### PR TITLE
Fix pagination inconsistency by ensuring a consistent ordering

### DIFF
--- a/substrate-archive/src/postgres/batch.rs
+++ b/substrate-archive/src/postgres/batch.rs
@@ -1021,7 +1021,7 @@ impl IdQuery for EventIdQuery {
             FROM event
             WHERE ($1 OR name = ANY($2))
                 AND block_id > $3 AND ($4 IS null OR block_id < $4)
-            ORDER BY block_id
+            ORDER BY block_id, id
             OFFSET $5
             LIMIT $6";
         let result = sqlx::query_as::<_, (String,)>(query)
@@ -1057,7 +1057,7 @@ impl IdQuery for CallIdQuery {
             FROM call
             WHERE ($1 OR name = ANY($2))
                 AND block_id > $3 AND ($4 IS null OR block_id < $4)
-            ORDER BY block_id
+            ORDER BY block_id, id
             OFFSET $5
             LIMIT $6";
         let result = sqlx::query_as::<_, (String,)>(query)
@@ -1092,7 +1092,7 @@ impl IdQuery for MessageEnqueuedIdQuery {
             FROM event
             WHERE name = 'Gear.MessageEnqueued' AND contract = ANY($1)
                 AND block_id > $2 AND ($3 IS null OR block_id < $3)
-            ORDER BY block_id
+            ORDER BY block_id, id
             OFFSET $4
             LIMIT $5";
         let result = sqlx::query_as::<_, (String,)>(query)


### PR DESCRIPTION
When we're loading IDs we paginate using LIMIT and OFFSET, but we only `ORDER BY` the block ID. Since different events/calls can have the same block ID this means the ordering of rows is not guaranteed to be consistent. For example, if we had an event with `ID = 'foo', block_id = 'block1'` and an event with `ID = 'bar', block_id='block1'`, when we query the DB those two rows can be returned in any order.

This means that if you're unlucky when we query for the next page of IDs, we may get IDs we've already seen instead of new IDs. This means that some data will be missing in our response. This was causing some events/calls to be randomly missing in our squid. The fix in this PR is to order by `id` after `block_id`, so that even if the block IDs are not unique the ordering of rows will be consistent. 